### PR TITLE
Add Railway deployment configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: streamlit run hibernate_bind_visualizer_app.py --server.port $PORT --server.address 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # hibernate-bind-visualizer-app
-hibernate-bind-visualizer-app
+
+A Streamlit tool to visualize bound SQL queries from Hibernate TRACE logs.
+
+## Local development
+
+```bash
+pip install -r requirements.txt
+streamlit run hibernate_bind_visualizer_app.py
+```
+
+## Deployment on Railway
+
+This repo includes a `Procfile` so Railway can launch the app:
+
+```
+web: streamlit run hibernate_bind_visualizer_app.py --server.port $PORT --server.address 0.0.0.0
+```
+
+To deploy:
+
+1. Create a new project on [Railway](https://railway.app) and connect this repository.
+2. Railway installs packages from `requirements.txt` and uses the `Procfile` to start the service.
+3. Visit the generated URL to use the app.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
## Summary
- add Procfile to run Streamlit with Railway's port
- document Railway deployment steps and local usage
- list Streamlit dependency

## Testing
- `python -m py_compile hibernate_bind_visualizer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2d286c71c8324915902801be2dc76