### PR TITLE
Add Vercel deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,25 @@ To deploy:
 2. Railway installs packages from `requirements.txt` and uses the `Procfile` to start the service.
 3. Visit the generated URL to use the app.
 
+## Deployment on Vercel
+
+The repository also ships with a `vercel.json` so the app can run on Vercel's
+Python runtime:
+
+```
+{
+  "builds": [
+    { "src": "hibernate_bind_visualizer_app.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "hibernate_bind_visualizer_app.py" }
+  ]
+}
+```
+
+To deploy:
+
+1. Push the repository to GitHub and import it into [Vercel](https://vercel.com).
+2. Vercel installs dependencies from `requirements.txt` and launches the app
+   using the configuration above.
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "hibernate_bind_visualizer_app.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "hibernate_bind_visualizer_app.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to run Streamlit app on Vercel
- document Vercel deployment steps

## Testing
- `python -m py_compile hibernate_bind_visualizer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2d485c4348324a4339985818e9a18