### PR TITLE
Handle null parameter values in visualizer

### DIFF
--- a/hibernate_bind_visualizer_app.py
+++ b/hibernate_bind_visualizer_app.py
@@ -120,6 +120,9 @@ def parse_logs(text: str) -> Tuple[List[Parameter], List[str]]:
 def normalize(param: Parameter, diagnostics: List[str], expand_in: bool) -> None:
     typ = param["type"]
     val = param["original"]
+    if val.lower() == "null":
+        param["normalized"] = "NULL"
+        return
     if typ in BOOLEAN_TYPES:
         v = val.lower()
         if v == "true":


### PR DESCRIPTION
## Summary
- Treat `null` log values as SQL `NULL` during normalization

## Testing
- `python -m py_compile hibernate_bind_visualizer_app.py`
- `python - <<'PY'
from hibernate_bind_visualizer_app import process
sql = 'select * from t where c = ?'
logs = '{"message":"binding parameter [1] as [VARCHAR] - [null]"}'
print(process(sql, logs, False)['final_sql'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a2e3b5fa40832481859810739e83be