### PR TITLE
Ensure Streamlit entrypoint always runs

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,6 @@
 from hibernate_bind_visualizer_app import main
 
-if __name__ == '__main__':
-    main()
+# Streamlit executes the script with a module name other than "__main__".
+# Calling main() at import time ensures the UI renders in all environments,
+# including platforms like Vercel that simply run this script.
+main()


### PR DESCRIPTION
## Summary
- Always invoke `main()` so Streamlit UI renders in hosted environments like Vercel

## Testing
- `python -m py_compile streamlit_app.py hibernate_bind_visualizer_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e7fa90f483248c888742c7d33cfe