### PR TITLE
Fix 404 by adding index entrypoint

### DIFF
--- a/index.py
+++ b/index.py
@@ -1,0 +1,6 @@
+"""Application entrypoint for hosting platforms that invoke `python index.py`."""
+
+from streamlit_app import _bootstrap
+
+if __name__ == "__main__":
+    _bootstrap()


### PR DESCRIPTION
## Summary
- Add `index.py` so hosting platforms that run `python index.py` properly bootstrap the Streamlit app

## Testing
- `python -m py_compile index.py streamlit_app.py hibernate_bind_visualizer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3f1c51ee8832486bb50a23df00419